### PR TITLE
Add Punjabi flashcards page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,3 +10,6 @@ main:
   #   url: /collection-archive/
   # - title: "Sitemap"
   #   url: /sitemap/
+
+  - title: "Flashcards"
+    url: /flashcards/

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -5,3 +5,19 @@
 @charset "utf-8";
 
 @import "minimal-mistakes";
+/* Flashcard styles */
+.flashcard {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  max-width: 400px;
+  margin: 2rem auto;
+  text-align: center;
+}
+.flashcard .answer {
+  margin-top: 1rem;
+  font-size: 1.2em;
+}
+.flashcard button {
+  margin: 0.5rem;
+}
+

--- a/assets/data/punjabi_words.json
+++ b/assets/data/punjabi_words.json
@@ -1,0 +1,2502 @@
+[
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  },
+  {
+    "gurmukhi": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ",
+    "transliteration": "sat sri akaal",
+    "english": "hello"
+  },
+  {
+    "gurmukhi": "ਧੰਨਵਾਦ",
+    "transliteration": "dhannvaad",
+    "english": "thank you"
+  },
+  {
+    "gurmukhi": "ਕਿਵੇਂ ਹੋ?",
+    "transliteration": "kiven ho?",
+    "english": "how are you?"
+  },
+  {
+    "gurmukhi": "ਪਾਣੀ",
+    "transliteration": "paani",
+    "english": "water"
+  },
+  {
+    "gurmukhi": "ਖਾਣਾ",
+    "transliteration": "khaana",
+    "english": "food"
+  },
+  {
+    "gurmukhi": "ਦੋਸਤ",
+    "transliteration": "dost",
+    "english": "friend"
+  },
+  {
+    "gurmukhi": "ਪਿਆਰ",
+    "transliteration": "pyaar",
+    "english": "love"
+  },
+  {
+    "gurmukhi": "ਸਕੂਲ",
+    "transliteration": "school",
+    "english": "school"
+  },
+  {
+    "gurmukhi": "ਕਿਤਾਬ",
+    "transliteration": "kitaab",
+    "english": "book"
+  },
+  {
+    "gurmukhi": "ਘਰ",
+    "transliteration": "ghar",
+    "english": "home"
+  }
+]

--- a/assets/js/flashcards.js
+++ b/assets/js/flashcards.js
@@ -1,0 +1,53 @@
+document.addEventListener('DOMContentLoaded', () => {
+  let words = [];
+  let index = 0;
+  let known = JSON.parse(localStorage.getItem('knownWords') || '[]');
+
+  function shuffle(array) {
+    for (let i = array.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [array[i], array[j]] = [array[j], array[i]];
+    }
+  }
+
+  function loadWords() {
+    fetch(FLASHCARD_DATA_URL)
+      .then(res => res.json())
+      .then(data => {
+        words = data;
+        shuffle(words);
+        index = 0;
+        showWord();
+      });
+  }
+
+  function showWord() {
+    if (index >= words.length) {
+      document.getElementById('card-word').textContent = 'All done!';
+      document.getElementById('card-answer').textContent = '';
+      return;
+    }
+    const w = words[index];
+    document.getElementById('card-word').textContent = w.gurmukhi;
+    document.getElementById('card-answer').textContent = `${w.transliteration} - ${w.english}`;
+    document.getElementById('card-answer').style.display = 'none';
+  }
+
+  document.getElementById('show-answer').addEventListener('click', () => {
+    document.getElementById('card-answer').style.display = 'block';
+  });
+
+  document.getElementById('known-btn').addEventListener('click', () => {
+    known.push(words[index]);
+    localStorage.setItem('knownWords', JSON.stringify(known));
+    index++;
+    showWord();
+  });
+
+  document.getElementById('unknown-btn').addEventListener('click', () => {
+    index++;
+    showWord();
+  });
+
+  loadWords();
+});

--- a/flashcards.html
+++ b/flashcards.html
@@ -1,0 +1,21 @@
+---
+layout: single
+title: Punjabi Flashcards
+permalink: /flashcards/
+---
+
+<div class="flashcard">
+  <div id="card-word" class="word"></div>
+  <div id="card-answer" class="answer" style="display:none;"></div>
+  <div class="buttons">
+    <button id="show-answer">Show Answer</button>
+    <button id="known-btn">Known</button>
+    <button id="unknown-btn">Unknown</button>
+  </div>
+</div>
+
+<script>
+  const FLASHCARD_DATA_URL = "{{ '/assets/data/punjabi_words.json' | relative_url }}";
+</script>
+<script src="{{ '/assets/js/flashcards.js' | relative_url }}"></script>
+


### PR DESCRIPTION
## Summary
- build a basic Punjabi flashcards page
- style flashcard component
- add JavaScript to drive flashcards and store known words in localStorage
- add placeholder Punjabi words dataset
- link the new page in site navigation

## Testing
- `npm run build:js` *(fails: uglifyjs not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850c9dd7568832fafa6a347ce8516df